### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/MSLesionSimulator/MSLesionSimulator.py
+++ b/MSLesionSimulator/MSLesionSimulator.py
@@ -250,7 +250,7 @@ class MSLesionSimulatorWidget(ScriptedLoadableModuleWidget):
     #
     self.outputFollowUpsSelector = ctk.ctkDirectoryButton()
     self.outputFollowUpsSelector.setToolTip("Output folder where follow-up image files will be saved.")
-    if platform.system() is "Windows":
+    if platform.system() == "Windows":
       home = expanduser("%userprofile%")
     else:
       home = expanduser("~")
@@ -517,7 +517,7 @@ class MSLesionSimulatorLogic(ScriptedLoadableModuleLogic):
 
     modulePath = os.path.dirname(slicer.modules.mslesionsimulator.path)
 
-    if platform.system() is "Windows":
+    if platform.system() == "Windows":
 
       databasePath = modulePath + "\\Resources\\MSlesion_database"
     else:
@@ -525,12 +525,12 @@ class MSLesionSimulatorLogic(ScriptedLoadableModuleLogic):
       databasePath = modulePath + "/Resources/MSlesion_database"
 
     if isBET:
-      if platform.system() is "Windows":
+      if platform.system() == "Windows":
         (readSuccess, MNINode)=slicer.util.loadVolume(databasePath+"\\MNI152_T1_1mm_brain.nii.gz",{},True)
       else:
         (readSuccess,MNINode)=slicer.util.loadVolume(databasePath + "/MNI152_T1_1mm_brain.nii.gz",{},True)
     else:
-      if platform.system() is "Windows":
+      if platform.system() == "Windows":
         (readSuccess, MNINode)=slicer.util.loadVolume(databasePath + "\\MNI152_T1_1mm.nii.gz",{},True)
       else:
         (readSuccess, MNINode)=slicer.util.loadVolume(databasePath + "/MNI152_T1_1mm.nii.gz",{},True)
@@ -560,7 +560,7 @@ class MSLesionSimulatorLogic(ScriptedLoadableModuleLogic):
 
     lesionMap = slicer.vtkMRMLLabelMapVolumeNode()
     slicer.mrmlScene.AddNode(lesionMap)
-    if platform.system() is "Windows":
+    if platform.system() == "Windows":
       self.doGenerateMask(MNINode, lesionLoad, lesionMap, databasePath+"\\labels-database")
     else:
       self.doGenerateMask(MNINode, lesionLoad, lesionMap, databasePath + "/labels-database")
@@ -991,10 +991,10 @@ class MSLesionSimulatorTest(ScriptedLoadableModuleTest):
     for url,name,loader in downloads:
       filePath = slicer.app.temporaryPath + '/' + name
       if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
+        logging.info(f'Requesting download {name} from {url}...\n')
         urllib.urlretrieve(url, filePath)
       if loader:
-        logging.info('Loading %s...' % (name,))
+        logging.info(f'Loading {name}...')
         loader(filePath)
     self.delayDisplay('Finished with download and loading')
 


### PR DESCRIPTION
Some syntax upgrading is necessary for Slicer-LesionSimulatorExtension as I noticed in https://slicer.cdash.org/viewBuildError.php?buildid=2625943 that there were syntax warnings. These warnings are present because Slicer recently upgrade from Python 3.6.7 to Python 3.9.10 in https://github.com/Slicer/Slicer/commit/34e48e8aef5dad19ec8a955d6f48a1940846e3f3.

The syntax warning in question started as of Python 3.8.
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in [bpo-34850](https://bugs.python.org/issue34850).)

This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. The script listed below was run for Python 3.6+ syntax with changes committed, followed by Python 3.7+, then Python 3.8+ and finally Python 3.9+.  There were no changes made when specifying Python 3.7+, 3.8+ or 3.9+ which is why there are no commits for those iterations.

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the Slicer repo. It was run by `PythonSlicer pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/Slicer-LesionSimulatorExtension"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py36-plus", file_path])
```